### PR TITLE
Compile with old MinGW 7.0.0 (GCC 7.5.0)

### DIFF
--- a/Basic2/Posix/runtime.c
+++ b/Basic2/Posix/runtime.c
@@ -43,11 +43,11 @@ uint8_t reltab = 0;
 
 /* the system type */
 #if defined(MSDOS)
-uint8_t bsystype = SYSTYPE_MSDOS
+uint8_t bsystype = SYSTYPE_MSDOS;
 #elif defined(RASPPI)
-uint8_t bsystype = SYSTYPE_PASPPI
+uint8_t bsystype = SYSTYPE_PASPPI;
 #elif defined(MINGW)
-uint8_t bsystype = SYSTYPE_MINGW
+uint8_t bsystype = SYSTYPE_MINGW;
 #elif defined(POSIX)
 uint8_t bsystype = SYSTYPE_POSIX;
 #else
@@ -1962,7 +1962,7 @@ char spistrbuf2[SPIRAMSBSIZE];
 uint32_t lastfasttick = 0;
 uint32_t fasttickcalls = 0;
 uint16_t avgfasttick = 0;
-int32_t devfasttick = 0;
+uint32_t devfasttick = 0;
 
 void fasttickerprofile() {
   if (lastfasttick == 0) { lastfasttick=micros(); return; }


### PR DESCRIPTION
Hi ,
after taking the [oldest 32Bit WinLabs MinGW](https://github.com/brechtsanders/winlibs_mingw/releases/download/7.5.0-7.0.0-r1/winlibs-i686-posix-dwarf-gcc-7.5.0-mingw-w64-7.0.0-r1.7z) or the [oldest 64Bit WinLabs MinGW](https://github.com/brechtsanders/winlibs_mingw/releases/download/7.5.0-7.0.0-r1/winlibs-x86_64-posix-seh-gcc-7.5.0-mingw-w64-7.0.0-r1.7z)
from their [website](https://github.com/brechtsanders/winlibs_mingw/releases?page=16) (all way down the page into the rabbit-hole)
I could compile your newest Basic2 (Basic 1.5a) with this MinGW 7.0.0 without errors :)
```
Filesystem started
Stefan's Basic 1.5a Memory 65535 1024
```

Before the additinal semicolons I did get an error about the const at line 85 - because (I think) the semicolons were missing.

and
```
runtime.c:1965:1: error: unknown type name 'int32_t'; did you mean 'uint
 int32_t devfasttick = 0;
 ^~~~~~~
 uint32_t
```

Please check.

This version need only to be unzipped (as extracted in a mingw32-folder) and then put there the extracted mingwvars.bat and execute it before the first compile from your source-directory ;)

[mingwvars.zip](https://github.com/slviajero/tinybasic/files/12598006/mingwvars.zip)

[Basic2_MinGW_compiled.zip](https://github.com/slviajero/tinybasic/files/12610860/Basic2_MinGW_compiled.zip)

Maybe this could help to rellace your old mingw 6.x you mentioned in the [Issue 50](https://github.com/slviajero/tinybasic/issues/50)

![IoTBASIC_MinGW_Calc_Pi1000](https://github.com/slviajero/tinybasic/assets/5121124/85ae21d4-5bce-400a-bcc9-1c305d14db21)

Kind regards
Guido



