### PR TITLE
Fix uninitialized bug into cstringlength

### DIFF
--- a/Basic2/MSDOS/basic.c
+++ b/Basic2/MSDOS/basic.c
@@ -1608,7 +1608,7 @@ void storecstring(address_t ax, address_t s, char* b) {
 
 /* length of a c string up to a limit l */
 address_t cstringlength(char* c, address_t l) {
-	address_t a;
+	address_t a = 0;
 
 	while(a < l && c[a] != 0) a++;
 	return a;

--- a/Basic2/Posix/basic.c
+++ b/Basic2/Posix/basic.c
@@ -1836,7 +1836,7 @@ void storecstring(address_t ax, address_t s, char* b) {
 
 /* length of a c string up to a limit l */
 address_t cstringlength(char* c, address_t l) {
-  address_t a;
+  address_t a = 0;
 
   while (a < l && c[a] != 0) a++;
   return a;

--- a/Basic2/RaspPi/basic.c
+++ b/Basic2/RaspPi/basic.c
@@ -1657,7 +1657,7 @@ void storecstring(address_t ax, address_t s, char* b) {
 
 /* length of a c string up to a limit l */
 address_t cstringlength(char* c, address_t l) {
-	address_t a;
+	address_t a = 0;
 
 	while(a < l && c[a] != 0) a++;
 	return a;

--- a/Basic2/Windows/basic.c
+++ b/Basic2/Windows/basic.c
@@ -1657,7 +1657,7 @@ void storecstring(address_t ax, address_t s, char* b) {
 
 /* length of a c string up to a limit l */
 address_t cstringlength(char* c, address_t l) {
-	address_t a;
+	address_t a = 0;
 
 	while(a < l && c[a] != 0) a++;
 	return a;


### PR DESCRIPTION
I made a project with VS 2022 and I tried to compile the BASIC interpreter, but it refused to build basic.c because there is a bug into `cstringlength()`.
Actually the variable `a` is not initialized to zero and Microsoft C compiler signals this as an error.
Attached patch fixes this error in all versions of the interpreter.